### PR TITLE
Teleport modifikation

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/MclRpEngine"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="E:/OneDrive - aggregate back-end e-services/Projekte/MCL Plugins/spigot-1.16.1.jar"/>
+	<classpathentry kind="lib" path="E:/OneDrive - aggregate back-end e-services/Projekte/MCL Plugins/Vault.jar"/>
+	<classpathentry kind="lib" path="E:/OneDrive - aggregate back-end e-services/Projekte/MCL Plugins/EssentialsX-2.17.2.147.jar"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Tpitem</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/src/de/mclroleplay/commands/SpawnCommand.java
+++ b/src/de/mclroleplay/commands/SpawnCommand.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.Player;
 import de.mclroleplay.config.MainCFG;
 import de.mclroleplay.config.SpawnsCFG;
 import de.mclroleplay.main.MclTpitem;
-import de.mclroleplay.rpengine.config.Messages;
+import de.mclroleplay.rpengine.config.MsgCFG;
 import de.mclroleplay.rpengine.config.PlayersCFG;
 
 public class SpawnCommand implements CommandExecutor {
@@ -32,7 +32,7 @@ public class SpawnCommand implements CommandExecutor {
 					// kein eco service
 					if (MclTpitem.economy == null) {
 						
-						Messages.sendMessage(p, "no_eco_service");
+						MsgCFG.sendMessage(p, "no_eco_service");
 						return true;
 						
 					}
@@ -40,7 +40,7 @@ public class SpawnCommand implements CommandExecutor {
 					// kein Geld
 					if (!MclTpitem.economy.has(p, MainCFG.getSpawnCost())) {
 						
-						Messages.sendMessage(p, "no_money");
+						MsgCFG.sendMessage(p, "no_money");
 						return true;
 						
 					}


### PR DESCRIPTION
In der neuesten MclRpEngine wurde die Klasse MessagesCFG zu MsgCFG umbenannt (wurde hier angepasst).
Desweiteren habe ich nun den eigentlichen Bukkit Teleport um den Essentials Teleport erweitert. Damit kann das Plugin die von Essentials bereitgestellten Teleportmethoden nutzen. Somit hat das Teleportitem auf dem MCL-Server einen Teleport-Cooldown etc.